### PR TITLE
The encoding and decoding of a Rule is not consistent

### DIFF
--- a/Sources/CertLogic/Rule.swift
+++ b/Sources/CertLogic/Rule.swift
@@ -181,7 +181,8 @@ public class Rule: Codable {
     try container.encode(validFrom, forKey: .validFrom)
     try container.encode(validTo, forKey: .validTo)
     try container.encode(affectedString, forKey: .affectedString)
-    try container.encode(affectedString, forKey: .affectedString)
+    try container.encode(logic, forKey: .logic)
+    try container.encode(countryCode, forKey: .countryCode)
   }
   
 }


### PR DESCRIPTION
i.e. not all fields are encoded, e.g.:

logic is decoded but not encoded in encode
countryCode is decoded not encoded in encode
affectedString is encoded twice