### PR TITLE
Fix casing in mapping of region in Business Rules

### DIFF
--- a/Sources/CertLogic/Rule.swift
+++ b/Sources/CertLogic/Rule.swift
@@ -130,7 +130,7 @@ public class Rule: Codable {
          affectedString = "AffectedFields",
          countryCode = "Country",
          logic = "Logic",
-         region,
+         region = "Region",
          hash
   }
   


### PR DESCRIPTION
According to the business rules schema (https://github.com/eu-digital-green-certificates/dgc-gateway/blob/main/src/main/resources/validation-rule.schema.json) the field Region starts with an uppercase letter. This is wrongly mapped in Rule.swift which means that no region is mapped.
